### PR TITLE
feat: run flake with args

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 
   outputs = { self, nixpkgs }: let pkgs = nixpkgs.legacyPackages.x86_64-linux; in
   {
-    packages.x86_64-linux.genix7000 = pkgs.writeScriptBin "genix7000" "${pkgs.openscad}/bin/openscad ${./genix.scad}";
+    packages.x86_64-linux.genix7000 = pkgs.writeScriptBin "genix7000" "${pkgs.openscad}/bin/openscad $@ ${./genix.scad}";
     packages.x86_64-linux.default = self.packages.x86_64-linux.genix7000;
   };
 }


### PR DESCRIPTION
now is possible to pass args to nix run ie:

`nix run github:cab404/genix7000  -- -o flake.png`

to save as PNG instead of opening the gui 

Next step is think how to accept more parameters and change your script :thinking: 