### PR TITLE
feat: different implementation for .mp4 outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To export as image without GUI
 
 ```bash
 nix run github:cab404/genix7000#to-image -- mynix.png "\#cd3535" "\#cd6b35" "\#cdb835"
+nix run github:cab404/genix7000#to-image -- mynix.svg
+nix run github:cab404/genix7000#to-image -- mynix.mp4 --animation '{ thick: ($thick + $i / 2), rotation: ($rotation - $i) }' --thick 1
 ```
 
 Flags:
@@ -48,10 +50,13 @@ Flags:
 - `--clipr <Int>`: Clipping ngon radius (default: 90)
 - `--cliprot <Int>`: Clipping ngon rotation (default: 90)
 - `--clipinv <Boolean>`: Inverse clipping order (default: false)
+- `--animation <String>`: video animation function (default: '{ rotation: ($rotation - $i) }')
+- `--fps <Int>`: video frame rate (default: 15)
+- `--duration <Int>`: video duration (default: 5)
 - `-h, --help`: Display the help message for this command
 
 Arguments:
-- `outfile <string>`: Image filename (optional, default: 'mynix.png')
+- `outfile <string>`: Image filename, ie mynix.svg, mynix.mp4 (optional, default: 'mynix.png')
 - `...colors <string>`: colors to use, ie "\#cd3535" "\#cd6b35" "\#cdb835"
 
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701968245,
-        "narHash": "sha256-o/l84ueCCSQEx2z6Icev5nFANgnw60jdqllc8CPo02k=",
+        "lastModified": 1710997485,
+        "narHash": "sha256-pKdA3ZHIEmcy7VEaaMkrXjtDX7lY5fnBuYQOvQSAlNY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42da68c40fb677791c10b1fff8f8febc87bba88e",
+        "rev": "9556d58fc97e4a1810129d6dd88c451fc2127aea",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,11 +11,11 @@
     (builtins.replaceStrings [
       "./genix.scad"
       "openscad"
-      "#!/usr/bin/env nu"
+      "/usr/bin/env nu"
     ] [
       "${./genix.scad}"
       "${pkgs.openscad}/bin/openscad"
-      "#!${pkgs.nushell}/bin/nu"
+      "${pkgs.nushell}/bin/nu"
     ] (builtins.readFile ./to-image.nu));
   };
 }

--- a/to-image.nu
+++ b/to-image.nu
@@ -1,6 +1,5 @@
 #!/usr/bin/env nu
 
-let dAnimation = "{ rotation: ($rotation - $i) }"
 
 # Export nix logo
 def main [
@@ -16,9 +15,9 @@ def main [
   --cliprot:int       = 90,              # Clipping ngon rotation
   --clipinv           = false,           # Inverse clipping order
   --fps:int           = 15               # video frame rate
-  --duration:int      = 5                # video duration
-  --animation:string  = dAnimation       # animation function
-  outfile:string      = "mynix.png",     # Image filename
+  --duration:int      = 4                # video duration
+  --animation:string  = "{ rotation: ($rotation - $i) }" # animation function
+  outfile:string      = "mynix.png",     # Image filename, ie mynix.svg, mynix.mp4
   ...colors:string                       # colors to use, ie "\#cd3535" "\#cd6b35" "\#cdb835"
 ] {
   let colors = if ($colors|length) > 0 { $colors|each {|it| $it|str replace "\\" ""} } else {

--- a/to-image.nu
+++ b/to-image.nu
@@ -1,42 +1,48 @@
 #!/usr/bin/env nu
 
+let dAnimation = "{ rotation: ($rotation - $i) }"
+
 # Export nix logo
 def main [
-  --num:int        = 7,               # Number of lambdas
-  --thick:int      = 20,              # Lambda thickness
-  --imgsize:string = "860,860",       # Image size in px
-  --offset:string  = "-30,-40",       # Offset of lambda
-  --gaps:string    = "-2,-2",         # Offset after clipping. Use for gaps.
-  --rotation:int   = 0,               # Rotation of each lambda
-  --angle:int      = 30,              # Lambda arm angle
-  --camera:string  = "0,0,480,0,0,0", # Image camera
-  --clipr:int      = 90,              # Clipping ngon radius
-  --cliprot:int    = 90,              # Clipping ngon rotation
-  --clipinv:bool   = false,           # Inverse clipping order
-  outfile:string   = "mynix.png",     # Image filename
-  ...colors:string                    # colors to use, ie "\#cd3535" "\#cd6b35" "\#cdb835"
+  --num:int           = 7,               # Number of lambdas
+  --thick:int         = 20,              # Lambda thickness
+  --imgsize:string    = "860,860",       # Image size in px
+  --offset:string     = "-30,-40",       # Offset of lambda
+  --gaps:string       = "-2,-2",         # Offset after clipping. Use for gaps.
+  --rotation:int      = 0,               # Rotation of each lambda
+  --angle:int         = 30,              # Lambda arm angle
+  --camera:string     = "0,0,480,0,0,0", # Image camera
+  --clipr:int         = 90,              # Clipping ngon radius
+  --cliprot:int       = 90,              # Clipping ngon rotation
+  --clipinv           = false,           # Inverse clipping order
+  --fps:int           = 15               # video frame rate
+  --duration:int      = 5                # video duration
+  --animation:string  = dAnimation       # animation function
+  outfile:string      = "mynix.png",     # Image filename
+  ...colors:string                       # colors to use, ie "\#cd3535" "\#cd6b35" "\#cdb835"
 ] {
   let colors = if ($colors|length) > 0 { $colors|each {|it| $it|str replace "\\" ""} } else {
     ["#cd3535", "#cd6b35", "#cdb835", "#35cd62", "#35cdc1", "#3577cd", "#9a35cd"]
   }
+  let params = {
+    clipr:   $clipr,
+    cliprot: $cliprot,
+    colors:  $"($colors)",
+    foff:    $"($offset|split row ',')",
+    gaps:    $"($gaps|split row ',')",
+    invclip: $clipinv,
+    larm:    $angle,
+    lrot:    $rotation,
+    num:     $num,
+    thick:   $thick
+  }
   let parameterSets = (mktemp) 
   {
     parameterSets: {
-      default: {
-        clipr:   $clipr,
-        cliprot: $cliprot,
-        colors:  $"($colors)",
-        foff:    $"($offset|split row ',')",
-        gaps:    $"($gaps|split row ',')",
-        invclip: $clipinv,
-        larm:    $angle,
-        lrot:    $rotation,
-        num:     $num,
-        thick:   $thick
-      }
+      default: $params
     }
   }|to json|save -f $parameterSets
-  if $outfile !~ ".svg$" {
+  if $outfile !~ ".svg$" and $outfile !~ ".mp4$" {
     (openscad
         -o $outfile
         -P default
@@ -44,6 +50,70 @@ def main [
         --imgsize $imgsize
         --camera  $camera
         ./genix.scad)
+  } else if $outfile =~ ".mp4$" {
+    let framesDir = (mktemp -d)
+    print $framesDir
+    let animationScript = $"($framesDir)/genix7000Animation.nu"
+    $"
+      let angle    = ($angle)
+      let camera   = ($camera|to nuon)
+      let clipinv  = ($clipinv|to nuon)
+      let clipr    = ($clipr)
+      let cliprot  = ($cliprot)
+      let gaps     = ($gaps|to nuon)
+      let imgsize  = ($imgsize|to nuon)
+      let num      = ($num)
+      let offset   = ($offset|to nuon)
+      let rotation = ($rotation)
+      let thick    = ($thick)
+
+      def main [i: int] {
+        ($animation)|to nuon
+      }
+    "|save -f $animationScript
+    1..($fps * $duration)|each {|i|
+      print $i
+      let parms = ({
+        angle:    $angle,
+        camera:   $camera,
+        clipinv:  $clipinv
+        clipr:    $clipr,
+        cliprot:  $cliprot,
+        colors:   $colors,
+        gaps:     $gaps,
+        imgsize:  $imgsize,
+        num:      $num,
+        offset:   $offset,
+        rotation: $rotation,
+        thick:    $thick,
+      }| merge (/usr/bin/env nu $animationScript $i|from nuon))
+      let frameNum = (printf '%010d' $i)
+      {
+        parameterSets: {
+          default: {
+            clipr:   $parms.clipr,
+            cliprot: $parms.cliprot,
+            colors:  $"($parms.colors)",
+            foff:    $"($parms.offset|split row ',')",
+            gaps:    $"($parms.gaps|split row ',')",
+            invclip: $parms.clipinv,
+            larm:    $parms.angle,
+            lrot:    $parms.rotation,
+            num:     $parms.num,
+            thick:   $parms.thick
+          }
+        }
+      }|to json|save -f $"($framesDir)/params($frameNum).json"
+     (openscad
+        -o $"($framesDir)/frame($frameNum).png"
+        -P default
+        -p $"($framesDir)/params($frameNum).json"
+        --imgsize $parms.imgsize
+        --camera  $parms.camera
+        ./genix.scad)
+    }
+    nix run github:NixOS/nixpkgs#ffmpeg -- -r $fps -pattern_type glob -i $"'($framesDir)/frame*.png'" $outfile
+    rm -rf $framesDir
   } else {
     let echOlors = "module color(c) {echo(str(c));}"
     let svg_path_re = "<path(\\n|\\N)*/>"


### PR DESCRIPTION
- Adding different output for .mp4
- Added 3 new parameters for command line
  - fps:int           = 15               # video frame rate
  - duration:int      = 4                # video duration
  - animation:string  = "{ rotation: ($rotation - $i) }" # animation function

Example:
```bash
nix run github:cab404/genix7000#to-image -- \
  mynix.mp4 --thick 1 \
  --animation '{ thick: ($thick + $i / 2), rotation: ($rotation - $i) }' 
```

![mad](https://github.com/cab404/genix7000/assets/863299/e72185c9-0590-44a2-ae82-e00b53534f23)


Caveat: ffmep is impure, called as `nix run`, so user don't have to download it if they don't need mp4 conversion.
