### PR TITLE
Fix `writeScriptBin` body in package definition

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724345964,
-        "narHash": "sha256-6zWAoNMYZ1UiL5PSIbQQguw78gkqCfWEwIun+qnl3iA=",
+        "lastModified": 1767387270,
+        "narHash": "sha256-GKhAzYh+RcBlU+zdtMJkg52rSGi00SxXOVlaAqLOvVA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c33918d57ccb75f511dd363588b5880e489549af",
+        "rev": "d804a77a856e4220d24239f7eecbd9cb897fa38c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,10 @@
 
   outputs = { self, nixpkgs }: let pkgs = nixpkgs.legacyPackages.x86_64-linux; in
   {
-    packages.x86_64-linux.genix7000 = pkgs.writeScriptBin "genix7000" "${pkgs.openscad}/bin/openscad $@ ${./genix.scad}";
+    packages.x86_64-linux.genix7000 = pkgs.writeScriptBin "genix7000" ''
+      #!${pkgs.runtimeShell}
+      ${pkgs.openscad}/bin/openscad $@ ${./genix.scad}
+    '';
     packages.x86_64-linux.default   = self.packages.x86_64-linux.genix7000;
     packages.x86_64-linux.to-image  = pkgs.writeScriptBin "to-image"
     (builtins.replaceStrings [


### PR DESCRIPTION
Fixes https://github.com/cab404/genix7000/issues/9

- added `pkgs.runtimeShell` to package inside `pkgs.writeScriptBin`
- updated flake.lock